### PR TITLE
Workaround Windows 7 wmic bug and fix linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "async": "1.5.0",
     "coffee-script": "1.10.0",
-    "csv-parse": "1.0.1"
+    "xml2js": "^0.4.17"
   },
   "devDependencies": {
     "chai": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "gulp-mocha": "2.2.0",
     "mocha": "2.3.4",
     "mocha-clean": "1.0.0"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/src/api-darwin.coffee
+++ b/src/api-darwin.coffee
@@ -14,7 +14,7 @@ getDefaultNetwork = (command, callback) ->
         return callback(new Error("parse error: #{stdout}"))
       if not net.isIP(defaultGateway)
         return callback(new Error("parse error: #{stdout}"))
-      data[defaultInterface] || = []
+      data[defaultInterface] = data[defaultInterface] || []
       family = switch net.isIP(defaultGateway)
         when 4 then 'IPv4'
         when 6 then 'IPv6'
@@ -42,7 +42,7 @@ collect = (callback) ->
       result = {}
       for data in [data4, data6]
         for iface, adapters of data
-          result[iface] || = []
+          result[iface] = result[iface] || []
           result[iface].push(adapters...)
       # collect() does not return errors
       callback(null, result)

--- a/src/api-linux.coffee
+++ b/src/api-linux.coffee
@@ -14,7 +14,7 @@ getDefaultNetwork = (command, callback) ->
         return callback(new Error("parse error: #{stdout}"))
       if not net.isIP(defaultGateway)
         return callback(new Error("parse error: #{stdout}"))
-      data[defaultInterface] || = []
+      data[defaultInterface] = data[defaultInterface] || []
       family = switch net.isIP(defaultGateway)
         when 4 then 'IPv4'
         when 6 then 'IPv6'
@@ -42,7 +42,7 @@ collect = (callback) ->
       result = {}
       for data in [data4, data6]
         for iface, adapters of data
-          result[iface] || = []
+          result[iface] = result[iface] || []
           result[iface].push(adapters...)
       # collect() does not return errors
       callback(null, result)

--- a/src/api-win32.coffee
+++ b/src/api-win32.coffee
@@ -44,10 +44,10 @@ getDefaultGateway = (callback) ->
       for address in defaultGateway.split(';')
         switch net.isIP(address)
           when 4
-            data[index] || = []
+            data[index] = data[index] || []
             data[index].push {family: 'IPv4', address: address}
           when 6
-            data[index] || = []
+            data[index] = data[index] || []
             data[index].push {family: 'IPv6', address: address}
           else
             return callback(new Error("#{address} is not IP address"))


### PR DESCRIPTION
The first commit works around a wmic bug present in Windows 7 when the regional setting differs from the system's locale. See http://stackoverflow.com/questions/9673057/wmic-error-invalid-xsl-format-in-windows7 for details.

The change forces the CSV output format to always be in `en-US` formatting, which is hopefully present on all installations where this module runs on.  A better solution might be to parse the unformatted output of `wmic`, because even in `en-US`, the CSV separator could be changed by the user.

The second commit fixes linter errors that are present on `master`.